### PR TITLE
Remove NDK select

### DIFF
--- a/azure/stages/build-xamarin-android.yml
+++ b/azure/stages/build-xamarin-android.yml
@@ -116,13 +116,7 @@ stages:
 - stage: ${{ parameters.stage_name }}
   dependsOn: ${{ parameters.depends_on }} 
   condition: and(succeeded(), ${{ parameters.build_enabled }})
-  variables: 
-    - name: ANDROID_NDK_HOME
-      value: C:\Microsoft\AndroidNDK64\android-ndk-r16b
-    - name: ANDROID_NDK_PATH
-      value: C:\Microsoft\AndroidNDK64\android-ndk-r16b
-    - name: AndroidNdkDirectory
-      value: C:\Microsoft\AndroidNDK64\android-ndk-r16b
+  variables:
     - name: manifestPath
       value: ${{ parameters.android_manifest_filename }}
     - name: outputSearch


### PR DESCRIPTION
Azure builds were failing because NDK 16 isn't installed by default anymore. Removing the selector means the build just takes default installed NDK now.